### PR TITLE
Use caller-skip to fix incorrect line number reporting

### DIFF
--- a/zapr.go
+++ b/zapr.go
@@ -153,10 +153,11 @@ func (l *zapLogger) WithName(name string) logr.Logger {
 
 // NewLogger creates a new logr.Logger using the given Zap Logger to log.
 func NewLogger(l *zap.Logger) logr.Logger {
+	log := l.WithOptions(zap.AddCallerSkip(1))
 	return &zapLogger{
-		l: l,
+		l: log,
 		infoLogger: infoLogger{
-			l:   l,
+			l:   log,
 			lvl: zap.InfoLevel,
 		},
 	}


### PR DESCRIPTION
Use zap.AddCallerSkip to refer to the correct line caller reference/file:linenum

Fixes #6 