### PR TITLE
bump go-logr/logr to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-logr/zapr
 go 1.12
 
 require (
-	github.com/go-logr/logr v0.2.0
+	github.com/go-logr/logr v0.2.1
 	go.uber.org/atomic v1.3.2
 	go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.8.0


### PR DESCRIPTION
bump go-logr/logr from v0.2.0 to v0.2.1 to include backward compatibility fix https://github.com/go-logr/logr/pull/20