### PR TITLE
RFC: support overriding String with reflection

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zapr
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+var field zap.Field
+
+//go:noinline
+func doZapAny(b *testing.B, value interface{}) {
+	var f zap.Field
+	for i := 0; i < b.N; i++ {
+		f = zapAny("value", value)
+	}
+	field = f
+}
+
+// Different types have different overhead, depending on how soon a casse
+// matches in
+// https://github.com/uber-go/zap/blob/eaeb0fc72fd23af7969c9a9f39e51b66827507ca/field.go#L413-L549
+
+func BenchmarkZapAny_kmeta(b *testing.B) {
+	doZapAny(b, KMeta{Namespace: "foo", Name: "bar"})
+}
+
+func BenchmarkZapAny_kmeta2(b *testing.B) {
+	doZapAny(b, KMeta2{KMeta: KMeta{Namespace: "foo", Name: "bar"}})
+}
+
+func BenchmarkZapAny_int(b *testing.B) {
+	doZapAny(b, 42)
+}
+
+func BenchmarkZapAny_bool(b *testing.B) {
+	doZapAny(b, true)
+}

--- a/kmeta_test.go
+++ b/kmeta_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zapr
+
+import (
+	"fmt"
+)
+
+// KMeta implements the Stringer interface for logging in text format.
+type KMeta struct {
+	Namespace, Name string
+}
+
+func (k KMeta) String() string {
+	if k.Namespace != "" {
+		return k.Namespace + "/" + k.Name
+	}
+	return k.Name
+}
+
+var _ fmt.Stringer = KMeta{}
+
+// KMeta2 adds the UseReflection interface.
+type KMeta2 struct {
+	KMeta
+}
+
+func (k KMeta2) LogWithReflection() {}
+
+var _ UseReflection = KMeta2{}

--- a/zapr.go
+++ b/zapr.go
@@ -54,6 +54,9 @@ limitations under the License.
 package zapr
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/go-logr/logr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -134,7 +137,7 @@ func (zl *zapLogger) handleFields(lvl int, args []interface{}, additional ...zap
 				continue
 			}
 			if zl.panicMessages {
-				zl.l.WithOptions(zap.AddCallerSkip(1)).DPanic("strongly-typed Zap Field passed to logr", zap.Any("zap field", args[i]))
+				zl.l.WithOptions(zap.AddCallerSkip(1)).DPanic("strongly-typed Zap Field passed to logr", zapAny("zap field", args[i]))
 			}
 			break
 		}
@@ -142,7 +145,7 @@ func (zl *zapLogger) handleFields(lvl int, args []interface{}, additional ...zap
 		// make sure this isn't a mismatched key
 		if i == len(args)-1 {
 			if zl.panicMessages {
-				zl.l.WithOptions(zap.AddCallerSkip(1)).DPanic("odd number of arguments passed as key-value pairs for logging", zap.Any("ignored key", args[i]))
+				zl.l.WithOptions(zap.AddCallerSkip(1)).DPanic("odd number of arguments passed as key-value pairs for logging", zapAny("ignored key", args[i]))
 			}
 			break
 		}
@@ -154,16 +157,370 @@ func (zl *zapLogger) handleFields(lvl int, args []interface{}, additional ...zap
 		if !isString {
 			// if the key isn't a string, DPanic and stop logging
 			if zl.panicMessages {
-				zl.l.WithOptions(zap.AddCallerSkip(1)).DPanic("non-string key argument passed to logging, ignoring all later arguments", zap.Any("invalid key", key))
+				zl.l.WithOptions(zap.AddCallerSkip(1)).DPanic("non-string key argument passed to logging, ignoring all later arguments", zapAny("invalid key", key))
 			}
 			break
 		}
 
-		fields = append(fields, zap.Any(keyStr, val))
+		fields = append(fields, zapAny(keyStr, val))
 		i += 2
 	}
 
 	return append(fields, additional...)
+}
+
+// TODO: move to logr
+//
+// UseReflection is an optional interface that values in a key/value list
+// may implement. That this interface is implemented provides a hint to
+// loggers that all fields in the value are meant to be logged via
+// reflection even when the logger normally would do something else,
+// like using the Stringer interface.
+//
+// Loggers are not required to support it. Depending on their purpose
+// or configuration, they might still prefer to use the Stringer interface,
+// for example when the goal is to provide human-readable output.
+type UseReflection interface {
+	// LogWithReflection will never get called and can be empty.
+	// It's existence already indicates the intent to prefer reflection
+	// for logging over alternatives like String.
+	LogWithReflection()
+}
+
+// zapAny is a fork of https://github.com/uber-go/zap/blob/eaeb0fc72fd23af7969c9a9f39e51b66827507ca/field.go#L413-L549
+// which adds support for logr.UseReflection
+func zapAny(key string, value interface{}) zapcore.Field {
+	switch val := value.(type) {
+	case UseReflection:
+		return zap.Reflect(key, val)
+	case zapcore.ObjectMarshaler:
+		return zap.Object(key, val)
+	case zapcore.ArrayMarshaler:
+		return zap.Array(key, val)
+	case bool:
+		return zap.Bool(key, val)
+	case *bool:
+		return zap.Boolp(key, val)
+	case []bool:
+		return zap.Bools(key, val)
+	case complex128:
+		return zap.Complex128(key, val)
+	case *complex128:
+		return zap.Complex128p(key, val)
+	case []complex128:
+		return zap.Complex128s(key, val)
+	case complex64:
+		return zap.Complex64(key, val)
+	case *complex64:
+		return zap.Complex64p(key, val)
+	case []complex64:
+		return zap.Complex64s(key, val)
+	case float64:
+		return zap.Float64(key, val)
+	case *float64:
+		return zap.Float64p(key, val)
+	case []float64:
+		return zap.Float64s(key, val)
+	case float32:
+		return zap.Float32(key, val)
+	case *float32:
+		return zap.Float32p(key, val)
+	case []float32:
+		return zap.Float32s(key, val)
+	case int:
+		return zap.Int(key, val)
+	case *int:
+		return zap.Intp(key, val)
+	case []int:
+		return zap.Ints(key, val)
+	case int64:
+		return zap.Int64(key, val)
+	case *int64:
+		return zap.Int64p(key, val)
+	case []int64:
+		return zap.Int64s(key, val)
+	case int32:
+		return zap.Int32(key, val)
+	case *int32:
+		return zap.Int32p(key, val)
+	case []int32:
+		return zap.Int32s(key, val)
+	case int16:
+		return zap.Int16(key, val)
+	case *int16:
+		return zap.Int16p(key, val)
+	case []int16:
+		return zap.Int16s(key, val)
+	case int8:
+		return zap.Int8(key, val)
+	case *int8:
+		return zap.Int8p(key, val)
+	case []int8:
+		return zap.Int8s(key, val)
+	case string:
+		return zap.String(key, val)
+	case *string:
+		return zap.Stringp(key, val)
+	case []string:
+		return zap.Strings(key, val)
+	case uint:
+		return zap.Uint(key, val)
+	case *uint:
+		return zap.Uintp(key, val)
+	case []uint:
+		return zap.Uints(key, val)
+	case uint64:
+		return zap.Uint64(key, val)
+	case *uint64:
+		return zap.Uint64p(key, val)
+	case []uint64:
+		return zap.Uint64s(key, val)
+	case uint32:
+		return zap.Uint32(key, val)
+	case *uint32:
+		return zap.Uint32p(key, val)
+	case []uint32:
+		return zap.Uint32s(key, val)
+	case uint16:
+		return zap.Uint16(key, val)
+	case *uint16:
+		return zap.Uint16p(key, val)
+	case []uint16:
+		return zap.Uint16s(key, val)
+	case uint8:
+		return zap.Uint8(key, val)
+	case *uint8:
+		return zap.Uint8p(key, val)
+	case []byte:
+		return zap.Binary(key, val)
+	case uintptr:
+		return zap.Uintptr(key, val)
+	case *uintptr:
+		return zap.Uintptrp(key, val)
+	case []uintptr:
+		return zap.Uintptrs(key, val)
+	case time.Time:
+		return zap.Time(key, val)
+	case *time.Time:
+		return zap.Timep(key, val)
+	case []time.Time:
+		return zap.Times(key, val)
+	case time.Duration:
+		return zap.Duration(key, val)
+	case *time.Duration:
+		return zap.Durationp(key, val)
+	case []time.Duration:
+		return zap.Durations(key, val)
+	case error:
+		return zap.NamedError(key, val)
+	case []error:
+		return zap.Errors(key, val)
+	case fmt.Stringer:
+		return zap.Stringer(key, val)
+	default:
+		return zap.Reflect(key, val)
+	}
+}
+
+func zapAny2(key string, value interface{}) zapcore.Field {
+	if val, ok := value.(UseReflection); ok {
+		return zap.Reflect(key, val)
+	}
+	return zap.Any(key, value)
+}
+
+func zapAny3(key string, value interface{}) zapcore.Field {
+	if val, ok := value.(UseReflection); ok {
+		return zap.Reflect(key, val)
+	}
+	if val, ok := value.(zapcore.ObjectMarshaler); ok {
+		return zap.Object(key, val)
+	}
+	if val, ok := value.(zapcore.ArrayMarshaler); ok {
+		return zap.Array(key, val)
+	}
+	if val, ok := value.(bool); ok {
+		return zap.Bool(key, val)
+	}
+	if val, ok := value.(*bool); ok {
+		return zap.Boolp(key, val)
+	}
+	if val, ok := value.([]bool); ok {
+		return zap.Bools(key, val)
+	}
+	if val, ok := value.(complex128); ok {
+		return zap.Complex128(key, val)
+	}
+	if val, ok := value.(*complex128); ok {
+		return zap.Complex128p(key, val)
+	}
+	if val, ok := value.([]complex128); ok {
+		return zap.Complex128s(key, val)
+	}
+	if val, ok := value.(complex64); ok {
+		return zap.Complex64(key, val)
+	}
+	if val, ok := value.(*complex64); ok {
+		return zap.Complex64p(key, val)
+	}
+	if val, ok := value.([]complex64); ok {
+		return zap.Complex64s(key, val)
+	}
+	if val, ok := value.(float64); ok {
+		return zap.Float64(key, val)
+	}
+	if val, ok := value.(*float64); ok {
+		return zap.Float64p(key, val)
+	}
+	if val, ok := value.([]float64); ok {
+		return zap.Float64s(key, val)
+	}
+	if val, ok := value.(float32); ok {
+		return zap.Float32(key, val)
+	}
+	if val, ok := value.(*float32); ok {
+		return zap.Float32p(key, val)
+	}
+	if val, ok := value.([]float32); ok {
+		return zap.Float32s(key, val)
+	}
+	if val, ok := value.(int); ok {
+		return zap.Int(key, val)
+	}
+	if val, ok := value.(*int); ok {
+		return zap.Intp(key, val)
+	}
+	if val, ok := value.([]int); ok {
+		return zap.Ints(key, val)
+	}
+	if val, ok := value.(int64); ok {
+		return zap.Int64(key, val)
+	}
+	if val, ok := value.(*int64); ok {
+		return zap.Int64p(key, val)
+	}
+	if val, ok := value.([]int64); ok {
+		return zap.Int64s(key, val)
+	}
+	if val, ok := value.(int32); ok {
+		return zap.Int32(key, val)
+	}
+	if val, ok := value.(*int32); ok {
+		return zap.Int32p(key, val)
+	}
+	if val, ok := value.([]int32); ok {
+		return zap.Int32s(key, val)
+	}
+	if val, ok := value.(int16); ok {
+		return zap.Int16(key, val)
+	}
+	if val, ok := value.(*int16); ok {
+		return zap.Int16p(key, val)
+	}
+	if val, ok := value.([]int16); ok {
+		return zap.Int16s(key, val)
+	}
+	if val, ok := value.(int8); ok {
+		return zap.Int8(key, val)
+	}
+	if val, ok := value.(*int8); ok {
+		return zap.Int8p(key, val)
+	}
+	if val, ok := value.([]int8); ok {
+		return zap.Int8s(key, val)
+	}
+	if val, ok := value.(string); ok {
+		return zap.String(key, val)
+	}
+	if val, ok := value.(*string); ok {
+		return zap.Stringp(key, val)
+	}
+	if val, ok := value.([]string); ok {
+		return zap.Strings(key, val)
+	}
+	if val, ok := value.(uint); ok {
+		return zap.Uint(key, val)
+	}
+	if val, ok := value.(*uint); ok {
+		return zap.Uintp(key, val)
+	}
+	if val, ok := value.([]uint); ok {
+		return zap.Uints(key, val)
+	}
+	if val, ok := value.(uint64); ok {
+		return zap.Uint64(key, val)
+	}
+	if val, ok := value.(*uint64); ok {
+		return zap.Uint64p(key, val)
+	}
+	if val, ok := value.([]uint64); ok {
+		return zap.Uint64s(key, val)
+	}
+	if val, ok := value.(uint32); ok {
+		return zap.Uint32(key, val)
+	}
+	if val, ok := value.(*uint32); ok {
+		return zap.Uint32p(key, val)
+	}
+	if val, ok := value.([]uint32); ok {
+		return zap.Uint32s(key, val)
+	}
+	if val, ok := value.(uint16); ok {
+		return zap.Uint16(key, val)
+	}
+	if val, ok := value.(*uint16); ok {
+		return zap.Uint16p(key, val)
+	}
+	if val, ok := value.([]uint16); ok {
+		return zap.Uint16s(key, val)
+	}
+	if val, ok := value.(uint8); ok {
+		return zap.Uint8(key, val)
+	}
+	if val, ok := value.(*uint8); ok {
+		return zap.Uint8p(key, val)
+	}
+	if val, ok := value.([]byte); ok {
+		return zap.Binary(key, val)
+	}
+	if val, ok := value.(uintptr); ok {
+		return zap.Uintptr(key, val)
+	}
+	if val, ok := value.(*uintptr); ok {
+		return zap.Uintptrp(key, val)
+	}
+	if val, ok := value.([]uintptr); ok {
+		return zap.Uintptrs(key, val)
+	}
+	if val, ok := value.(time.Time); ok {
+		return zap.Time(key, val)
+	}
+	if val, ok := value.(*time.Time); ok {
+		return zap.Timep(key, val)
+	}
+	if val, ok := value.([]time.Time); ok {
+		return zap.Times(key, val)
+	}
+	if val, ok := value.(time.Duration); ok {
+		return zap.Duration(key, val)
+	}
+	if val, ok := value.(*time.Duration); ok {
+		return zap.Durationp(key, val)
+	}
+	if val, ok := value.([]time.Duration); ok {
+		return zap.Durations(key, val)
+	}
+	if val, ok := value.(error); ok {
+		return zap.NamedError(key, val)
+	}
+	if val, ok := value.([]error); ok {
+		return zap.Errors(key, val)
+	}
+	if val, ok := value.(fmt.Stringer); ok {
+		return zap.Stringer(key, val)
+	}
+
+	return zap.Reflect(key, value)
 }
 
 func (zl *zapLogger) Init(ri logr.RuntimeInfo) {


### PR DESCRIPTION
If a value implements the UseReflection interface by providing a
LogWithReflection method, then the normal handling (in particular, using the
Stringer interface if available) is overridden and the value gets
logged via reflection.

This is useful for klog.ObjectRef which provides a String method for logging as
plain text, but is meant to be logged as struct when using JSON output.