### PR TITLE
WIP: implement flushing on demand

### DIFF
--- a/zapr.go
+++ b/zapr.go
@@ -214,6 +214,18 @@ func (zl *zapLogger) WithCallDepth(depth int) logr.LogSink {
 	return &newLogger
 }
 
+// FlushLogSink is an interface implemented by zapr to trigger flushing.
+type FlushLogSink interface {
+	// Flush invokes Sync() on the underlying zap logger.
+	Flush()
+}
+
+func (zl *zapLogger) Flush() {
+	_ = zl.l.Sync()
+}
+
+var _ FlushLogSink = &zapLogger{}
+
 // Underlier exposes access to the underlying logging implementation.  Since
 // callers only have a logr.Logger, they have to know which implementation is
 // in use, so this interface is less of an abstraction and more of way to test


### PR DESCRIPTION
Flushing through a method provided by the zapr LogSink makes it easier for
consumers who only have access to the abstract logr.Logger to flush buffered
messages. Other LogSinks might implement the same interface.

The alternative is to go through Underlier, but that is more complicated and
more tightly couples the caller with details of the LogSink.