### PR TITLE
Refresh go version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-versions: [ 1.18.x, 1.19.x, 1.20.x ]
+        go-versions: [ 1.20.x, 1.21.x, 1.22.x ]
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
After releasing Go 1.22 go 1.20 reached end of life. 