### PR TITLE
Update slogtest empty-group-record explanation

### DIFF
--- a/slog_test.go
+++ b/slog_test.go
@@ -63,8 +63,8 @@ func TestSlogHandler(t *testing.T) {
 		}); ok {
 			for _, err := range err.Unwrap() {
 				if !containsOne(err.Error(),
-					"a Handler should ignore a zero Record.Time",             // zapr always writes a time field.
-					"a Handler should not output groups for an empty Record", // Relies on WithGroup and that always opens a group. Text may change, see https://go.dev/cl/516155
+					"a Handler should ignore a zero Record.Time",                    // zapr always writes a time field.
+					"a Handler should not output groups if there are no attributes", // Relies on WithGroup and that always opens a group.
 				) {
 					t.Errorf("Unexpected error: %v", err)
 				}


### PR DESCRIPTION
The commit https://go.dev/cl/516155 changed the explanation regarding empty group handling, causing **TestSlogHandler** to fail.

This Pull Request updates the corresponding test message:
- Replaced "a Handler should not output groups for an empty Record"
- With "a Handler should not output groups if there are no attributes".

https://cs.opensource.google/go/go/+/master:src/testing/slogtest/slogtest.go;l=161

This aligns the test with the new behavior and ensures it passes.