### PR TITLE
drop +build tags

### DIFF
--- a/slog_test.go
+++ b/slog_test.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 /*
 Copyright 2023 The logr Authors.

--- a/slogzapr.go
+++ b/slogzapr.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 /*
 Copyright 2023 The logr Authors.

--- a/zapr_noslog.go
+++ b/zapr_noslog.go
@@ -1,5 +1,4 @@
 //go:build !go1.21
-// +build !go1.21
 
 /*
 Copyright 2023 The logr Authors.

--- a/zapr_noslog_test.go
+++ b/zapr_noslog_test.go
@@ -1,5 +1,4 @@
 //go:build !go1.21 && !go1.21
-// +build !go1.21,!go1.21
 
 /*
 Copyright 2023 The logr Authors.

--- a/zapr_slog.go
+++ b/zapr_slog.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 /*
 Copyright 2023 The logr Authors.

--- a/zapr_slog_test.go
+++ b/zapr_slog_test.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 /*
 Copyright 2023 The logr Authors.


### PR DESCRIPTION
Our minimal Go version is 1.18, which already supported go:build (https://pkg.go.dev/go/build@go1.18#hdr-Build_Constraints).

Newer govet complains about the unnecessary +build, so let's remove them.